### PR TITLE
Issue 14

### DIFF
--- a/src/EPA-CEMS/netToGrossCalculation.R
+++ b/src/EPA-CEMS/netToGrossCalculation.R
@@ -231,7 +231,7 @@ crosswalk %>%
   distinct(orispl.code,cems.unit.id,year,unit.group) -> crosswalk.cems
 
 crosswalk.cems %>% 
-  count(orispl.code,cems.unit.id,year) %>%
+  dplyr::count(orispl.code,cems.unit.id,year) %>%
   filter(n > 1) -> duplicated.keys
 
 if(nrow(duplicated.keys) > 0) {


### PR DESCRIPTION
Resolve #14 Explicitly reference `dplyr::count()` to avoid ambiguity if another package masks it.